### PR TITLE
Added 1 line per language for display usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensebox/opensensemap-i18n",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "description": "Messages and its translations used by openSenseMap and openSenseMap-API",
   "license": "MIT",
   "publishConfig": {

--- a/src/registration/de_DE.json
+++ b/src/registration/de_DE.json
@@ -35,6 +35,7 @@
   "DIGITAL_PORT": "Digitaler Port",
   "SOUND_LEVEL": "Lautstärke",
   "WIND_SPEED": "Windgeschwindigkeit",
+  "DISPLAY_ENABLED":"Display einschalten",
   "LD_INFO_SDS_WITHOUT_TEMP": "Luftdaten.info Feinstaubsensor (SDS011) ohne Temperatur-/Feuchtesensor",
   "LD_INFO_SDS_WITH": "Luftdaten.info Feinstaubsensor (SDS011) mit",
   "LD_INFO_PMS7003_WITH_BME": "Luftdaten.info Feinstaubsensor (PMS7003) mit BME280",

--- a/src/registration/de_DE.json
+++ b/src/registration/de_DE.json
@@ -35,7 +35,7 @@
   "DIGITAL_PORT": "Digitaler Port",
   "SOUND_LEVEL": "Lautstärke",
   "WIND_SPEED": "Windgeschwindigkeit",
-  "DISPLAY_ENABLED":"Display einschalten",
+  "DISPLAY_ENABLED":"OLED Display einschalten",
   "LD_INFO_SDS_WITHOUT_TEMP": "Luftdaten.info Feinstaubsensor (SDS011) ohne Temperatur-/Feuchtesensor",
   "LD_INFO_SDS_WITH": "Luftdaten.info Feinstaubsensor (SDS011) mit",
   "LD_INFO_PMS7003_WITH_BME": "Luftdaten.info Feinstaubsensor (PMS7003) mit BME280",

--- a/src/registration/en_US.json
+++ b/src/registration/en_US.json
@@ -35,6 +35,7 @@
   "DIGITAL_PORT": "Digital port",
   "SOUND_LEVEL": "Sound Level",
   "WIND_SPEED": "Wind speed",
+  "DISPLAY_ENABLED":"Display einschalten",
   "LD_INFO_SDS_WITHOUT_TEMP": "Luftdaten.info dust particle sensor (SDS011) without temperature-/humidity Sensor",
   "LD_INFO_SDS_WITH": "Luftdaten.info dust particle sensor (SDS011) with",
   "LD_INFO_PMS7003_WITH_BME": "Luftdaten.info dust particle sensor (PMS7003) with BME280",

--- a/src/registration/en_US.json
+++ b/src/registration/en_US.json
@@ -35,7 +35,7 @@
   "DIGITAL_PORT": "Digital port",
   "SOUND_LEVEL": "Sound Level",
   "WIND_SPEED": "Wind speed",
-  "DISPLAY_ENABLED":"Display einschalten",
+  "DISPLAY_ENABLED":"Enable OLED display",
   "LD_INFO_SDS_WITHOUT_TEMP": "Luftdaten.info dust particle sensor (SDS011) without temperature-/humidity Sensor",
   "LD_INFO_SDS_WITH": "Luftdaten.info dust particle sensor (SDS011) with",
   "LD_INFO_PMS7003_WITH_BME": "Luftdaten.info dust particle sensor (PMS7003) with BME280",


### PR DESCRIPTION
For the upcoming changes to the registration which will incorporate the display, 2 translations were needed. 

Version number has been bumped as well for rebuilding